### PR TITLE
Issue20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@
 * The `SaturationColorSlider` and `LightnessColorSlider`
   controls now display a checker box background for non-solid
   colours
+* The `ColorGrid` control wasn't binding events for the default
+  `Colors` and `CustomColors` property values, causing
+  programmatic changes not to be reflected in the control or
+  crashes trying to access values not present
+* Calling `ColorGrid.EndUpdate` didn't perform layout operations
+  if the total number of colours had changed whiles updating was
+  disabled
 
 ### 1.8.0
 

--- a/Cyotek.Windows.Forms.ColorPicker/ColorGrid.cs
+++ b/Cyotek.Windows.Forms.ColorPicker/ColorGrid.cs
@@ -1,10 +1,13 @@
-// Cyotek Color Picker controls library
-// Copyright © 2013-2021 Cyotek Ltd.
+// Cyotek Color Picker Controls Library
 // http://cyotek.com/blog/tag/colorpicker
 
-// Licensed under the MIT License. See license.txt for the full text.
+// Copyright (c) 2013-2021 Cyotek Ltd.
 
-// If you use this code in your applications, donations or attribution are welcome
+// This work is licensed under the MIT License.
+// See LICENSE.TXT for the full text
+
+// Found this code useful?
+// https://www.cyotek.com/contribute
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
* The `ColorGrid` control wasn't binding events for the default
  `Colors` and `CustomColors` property values, causing
  programmatic changes not to be reflected in the control or
  crashes trying to access values not present
* Calling `ColorGrid.EndUpdate` didn't perform layout operations
  if the total number of colours had changed whiles updating was
  disabled